### PR TITLE
Add support for NGINX keyword directives

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.3.0 (2026-01-28)
+------------------
+
+* @nbtm-sh add support for single word keywords
+
 0.2.1 (2022-03-24)
 ------------------
 

--- a/chibi_nginx/nginx.py
+++ b/chibi_nginx/nginx.py
@@ -29,6 +29,9 @@ def iter_to_string( d, tabs=0 ):
                     yield f'{t}{k}' + ' {'
                     yield from iter_to_string( vv, tabs + 1 )
                     yield f'{t}' + '}'
+                elif isinstance( vv, bool ):
+                    if vv:
+                        yield f'{t}{k};'
                 else:
                     yield f'{t}{k} {vv};'
         else:

--- a/chibi_nginx/nginx.py
+++ b/chibi_nginx/nginx.py
@@ -51,7 +51,6 @@ def parse_internal( content_iter ):
             content = filter( bool, content )
             content = map( str.strip, content )
             content = list( content )
-            print(content)
             result[ content[0].rstrip( ';' ) ] = clean_value( content[1:] )
     return result
 

--- a/chibi_nginx/nginx.py
+++ b/chibi_nginx/nginx.py
@@ -59,6 +59,8 @@ def clean_value( content ):
     if len( content ) == 1:
         result = content[0]
         result = result.rstrip( ';' )
-    else:
+    elif len( content ) == 0:
         return True
+    else:
+        raise NotImplementedError()
     return result

--- a/chibi_nginx/nginx.py
+++ b/chibi_nginx/nginx.py
@@ -51,7 +51,8 @@ def parse_internal( content_iter ):
             content = filter( bool, content )
             content = map( str.strip, content )
             content = list( content )
-            result[ content[0] ] = clean_value( content[1:] )
+            print(content)
+            result[ content[0].rstrip( ';' ) ] = clean_value( content[1:] )
     return result
 
 

--- a/chibi_nginx/nginx.py
+++ b/chibi_nginx/nginx.py
@@ -60,5 +60,5 @@ def clean_value( content ):
         result = content[0]
         result = result.rstrip( ';' )
     else:
-        raise NotImplementedError()
+        return True
     return result

--- a/chibi_nginx/nginx.py
+++ b/chibi_nginx/nginx.py
@@ -29,11 +29,11 @@ def iter_to_string( d, tabs=0 ):
                     yield f'{t}{k}' + ' {'
                     yield from iter_to_string( vv, tabs + 1 )
                     yield f'{t}' + '}'
-                elif isinstance( vv, bool ):
-                    if vv:
-                        yield f'{t}{k};'
                 else:
                     yield f'{t}{k} {vv};'
+        elif isinstance( v, bool ):
+            if v:
+                yield f'{t}{k};'
         else:
             yield f'{t}{k} {v};'
 

--- a/tests/test_chibi_nginx.py
+++ b/tests/test_chibi_nginx.py
@@ -86,6 +86,50 @@ nginx_expected = {
     'worker_rlimit_nofile': '30000'
 }
 
+nginx_to_string_expected_false = """worker_processes 2;
+worker_rlimit_nofile 30000;
+events {
+	worker_connections 10000;
+	accept_mutex off;
+}
+http {
+	include /etc/nginx/conf.d/*.conf;
+	include mime.types;
+	include /etc/nginx/sites_enabled/*;
+	default_type json;
+	sendfile off;
+	keepalive_timeout 65;
+	access_log /var/log/nginx/access.log upstream_time;
+	error_log /var/log/nginx/error.log;
+	server {
+		listen 80 default_server;
+		return 444;
+	}
+}"""
+nginx_expected_false = {
+    'events': {
+        'accept_mutex': 'off', 'worker_connections': '10000'
+    },
+    'http': {
+        'access_log': '/var/log/nginx/access.log upstream_time',
+        'default_type': 'json',
+        'error_log': '/var/log/nginx/error.log',
+        'include': [
+            '/etc/nginx/conf.d/*.conf',
+            'mime.types',
+            '/etc/nginx/sites_enabled/*' ],
+        'keepalive_timeout': '65',
+        'sendfile': 'off',
+        'server': {
+            'listen': '80 default_server',
+            'return': '444',
+            'internal': False 
+        }
+    },
+    'worker_processes': '2',
+    'worker_rlimit_nofile': '30000'
+}
+
 
 class Test_chibi_nginx( unittest.TestCase ):
     def setUp(self):

--- a/tests/test_chibi_nginx.py
+++ b/tests/test_chibi_nginx.py
@@ -31,6 +31,7 @@ http {
 	server {
 		listen 80 default_server;
 		return 444;
+		internal;
 	}
 
 	include /etc/nginx/sites_enabled/*;
@@ -57,6 +58,7 @@ http {
 	server {
 		listen 80 default_server;
 		return 444;
+		internal;
 	}
 }"""
 
@@ -76,7 +78,8 @@ nginx_expected = {
         'sendfile': 'off',
         'server': {
             'listen': '80 default_server',
-            'return': '444'
+            'return': '444',
+            'internal': True
         }
     },
     'worker_processes': '2',
@@ -122,7 +125,7 @@ class Test_chibi_nginx_file( TestCase ):
                 'keepalive_timeout': '65',
                 'sendfile': 'off',
                 'server': {
-                    'listen': '80 default_server', 'return': '444'
+                    'listen': '80 default_server', 'return': '444', 'internal': True
                 }
             },
             'worker_processes': '2',

--- a/tests/test_chibi_nginx.py
+++ b/tests/test_chibi_nginx.py
@@ -147,6 +147,10 @@ class Test_chibi_nginx( unittest.TestCase ):
         result = to_string( data )
         self.assertEqual( result, nginx_to_string_expected )
 
+    def test_to_string_should_work_false(self):
+        result = to_string( nginx_expected_false )
+        self.assertEqual( result, nginx_to_string_expected_false )
+
 
 class Test_chibi_nginx_file( TestCase ):
     def setUp( self ):

--- a/tests/test_chibi_nginx.py
+++ b/tests/test_chibi_nginx.py
@@ -86,26 +86,27 @@ nginx_expected = {
     'worker_rlimit_nofile': '30000'
 }
 
-nginx_to_string_expected_false = """worker_processes 2;
-worker_rlimit_nofile 30000;
-events {
-	worker_connections 10000;
+nginx_to_string_expected_false = """events {
 	accept_mutex off;
+	worker_connections 10000;
 }
 http {
+	access_log /var/log/nginx/access.log upstream_time;
+	default_type json;
+	error_log /var/log/nginx/error.log;
 	include /etc/nginx/conf.d/*.conf;
 	include mime.types;
 	include /etc/nginx/sites_enabled/*;
-	default_type json;
-	sendfile off;
 	keepalive_timeout 65;
-	access_log /var/log/nginx/access.log upstream_time;
-	error_log /var/log/nginx/error.log;
+	sendfile off;
 	server {
 		listen 80 default_server;
 		return 444;
 	}
-}"""
+}
+worker_processes 2;
+worker_rlimit_nofile 30000;"""
+
 nginx_expected_false = {
     'events': {
         'accept_mutex': 'off', 'worker_connections': '10000'


### PR DESCRIPTION
Hello @dem4ply ,

I would like to use your library in my project, [Kagemori](https://github.com/nbtm-sh/kagemori), to replace some very janky code. In my testing, I noticed that the library does not support single-word directives such as [internal](https://nginx.org/en/docs/http/ngx_http_core_module.html#internal).

I aim to address this issue in the PR. I have added the necessary tests. Happy to discuss a better implementation if needed.

Cheers,
Nathan